### PR TITLE
fix: redirect http to https at load balancer

### DIFF
--- a/infrastructure/ecs_services/alb.tf
+++ b/infrastructure/ecs_services/alb.tf
@@ -50,6 +50,22 @@ resource "aws_alb_listener" "ecs-alb-https" {
   depends_on = [aws_alb_target_group.ecs-default-target-grp]
 }
 
+resource "aws_alb_listener" "ecs-alb-http-to-https" {
+  load_balancer_arn = aws_alb.airflow_webserver.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  depends_on = [aws_alb_target_group.ecs-default-target-grp]
+}
 
 
 


### PR DESCRIPTION
Redirect HTTP traffic to HTTPS from the ALB. This fixes the Github auth flow when using Firefox (Chrome handles this redirect by default on the client side)