### PR TITLE
upgrade build to python 3.11

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:slim-2.7.0-python3.10
+FROM apache/airflow:slim-2.7.0-python3.11
 
 USER root
 # `apt-get autoremove` is used to remove packages that were automatically installed to satisfy


### PR DESCRIPTION
# What
Upgrade to python 3.11, in particular, we want this datetime isoformat improvement

>Changed in version 3.11: Previously, this method only supported formats that could be emitted by [date.isoformat()](https://docs.python.org/3.11/library/datetime.html#datetime.date.isoformat) or [datetime.isoformat()](https://docs.python.org/3.11/library/datetime.html#datetime.datetime.isoformat).