### PR TITLE
Add dependency on DB for user creation

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -98,7 +98,7 @@ module "ecs_services" {
 }
 
 resource "null_resource" "airflow_create_airflow_user" {
-  depends_on = [module.ecs_services]
+  depends_on = [module.ecs_services, module.database]
   triggers = {
     admin_password = var.airflow_admin_password
     admin_username = var.airflow_admin_username


### PR DESCRIPTION
I think it's possible for the `create_user` step to be executed and fail silently if the DB is not created first. This PR adds an additional dependency, which should be enough to avoid this issue.