### PR TITLE
fix: define local subdomain variable for certificates

### DIFF
--- a/infrastructure/ecs_services/certificate.tf
+++ b/infrastructure/ecs_services/certificate.tf
@@ -1,4 +1,8 @@
 
+locals {
+  subdomain = var.subdomain == "null" ? var.stage : var.subdomain
+}
+
 resource "aws_acm_certificate" "ecs-domain-certificate" {
   domain_name       = "${lower(local.subdomain)}.${var.domain_name}"
   validation_method = "DNS"


### PR DESCRIPTION
Testing veda-data-airflow with UAH `dev` and UAH `sit` reveals that the `ecs_services` module is looking for the parent domain `openveda.cloud` when it should be looking at the subdomain since we have adopted the subdomain delegation pattern for DNS resources and our UAH stacks do not have access to modify the SMCE authoritative hosted zone. 

I was able to validate this through an unsuccessful SIT deployment run https://github.com/NASA-IMPACT/veda-deploy/actions/runs/15478385611/job/43587068714 and another deployment run for DEV: https://github.com/NASA-IMPACT/veda-data-airflow/actions/runs/15164690026/job/43638886996 with `domain` set to `dev.openveda.cloud` in the secrets. 