### PR TITLE
fix: move subdomain to locals.tf

### DIFF
--- a/infrastructure/ecs_services/alb.tf
+++ b/infrastructure/ecs_services/alb.tf
@@ -1,8 +1,3 @@
-
-locals {
-  subdomain = var.subdomain == "null" ? var.stage : var.subdomain
-}
-
 resource "aws_alb" "airflow_webserver" {
   name            = "${var.prefix}-webserver"
   internal        = false
@@ -67,8 +62,6 @@ resource "aws_alb_listener" "ecs-alb-http-to-https" {
   depends_on = [aws_alb_target_group.ecs-default-target-grp]
 }
 
-
-
 resource "aws_alb_target_group" "ecs-app-target-group" {
   name        = "${var.prefix}-app-tg"
   port        = 8080 # docker port
@@ -90,8 +83,6 @@ resource "aws_alb_target_group" "ecs-app-target-group" {
   }
 }
 
-
-
 resource "aws_alb_listener_rule" "ecs-alb-listener-role" {
   listener_arn = aws_alb_listener.ecs-alb-https.arn
   action {
@@ -104,8 +95,6 @@ resource "aws_alb_listener_rule" "ecs-alb-listener-role" {
     }
   }
 }
-
-
 
 resource "aws_security_group" "airflow_webserver_alb" {
   name_prefix = "${var.prefix}-webserver-alb-"

--- a/infrastructure/ecs_services/certificate.tf
+++ b/infrastructure/ecs_services/certificate.tf
@@ -1,8 +1,3 @@
-
-locals {
-  subdomain = var.subdomain == "null" ? var.stage : var.subdomain
-}
-
 resource "aws_acm_certificate" "ecs-domain-certificate" {
   domain_name       = "${lower(local.subdomain)}.${var.domain_name}"
   validation_method = "DNS"

--- a/infrastructure/ecs_services/locals.tf
+++ b/infrastructure/ecs_services/locals.tf
@@ -1,13 +1,11 @@
 locals {
-
+  subdomain           = var.subdomain == "null" ? var.stage : var.subdomain
   services_build_path = "../${path.root}/airflow_services"
   dag_folder_path     = "../${path.root}/dags"
   scripts_path        = "../${path.root}/scripts"
   config_path         = "../${path.root}/infrastructure/configuration"
   worker_build_path   = "../${path.root}/airflow_worker"
   config_files        = [for f in fileset(local.config_path, "**") : f if f != "airflow.cfg"]
-
-
 }
 
 


### PR DESCRIPTION
> Error: Duplicate local value definition
│ 
│   on .terraform/modules/sma-base/ecs_services/certificate.tf line 3, in locals:
│    3:   subdomain = var.subdomain == "null" ? var.stage : var.subdomain
│ 
│ A local value named "subdomain" was already defined at
│ .terraform/modules/sma-base/ecs_services/alb.tf:3,3-66. Local value names
│ must be unique within a module.

I didn't realize we had defined this already and I think moving it to locals.tf is better practice anyway. 