### PR TITLE
feat: upgrade Airflow to 2.8.4

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:slim-2.7.0-python3.10
+FROM apache/airflow:slim-2.8.4-python3.10
 
 USER root
 # `apt-get autoremove` is used to remove packages that were automatically installed to satisfy
@@ -6,7 +6,7 @@ USER root
 # `apt-get clean` clears out the local repository of retrieved package files
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends gcc libc6-dev libcurl4-openssl-dev libssl-dev \ 
+  && apt-get install -y --no-install-recommends gcc libc6-dev libcurl4-openssl-dev libssl-dev \
   && apt-get autoremove -yqq --purge \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
@@ -16,7 +16,7 @@ COPY --chown=airflow:airflow requirements.txt "${AIRFLOW_HOME}/requirements.txt"
 USER airflow
 
 RUN pip install --upgrade pip \
-  && pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.0/constraints-3.10.txt"
+  && pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.4/constraints-3.10.txt"
 
 COPY --chown=airflow:airflow dags "${AIRFLOW_HOME}/dags"
 COPY --chown=airflow:airflow plugins "${AIRFLOW_HOME}/plugins"

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -36,8 +36,8 @@ ENV PATH $PATH:/home/airflow/.local/bin
 COPY --chown=airflow:airflow requirements.txt "${AIRFLOW_HOME}/requirements.txt"
 
 RUN pip install --upgrade pip \
-    && pip install "apache-airflow[celery,amazon]==2.7.0" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.0/constraints-3.10.txt" \
-    && pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.0/constraints-3.10.txt"
+    && pip install "apache-airflow[celery,amazon]==2.8.4" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.4/constraints-3.10.txt" \
+    && pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.4/constraints-3.10.txt"
 
 
 COPY --chown=airflow:airflow dags "${AIRFLOW_HOME}/dags"


### PR DESCRIPTION
Since veda-data-airflow is on version 2.8.4, I think we need to upgrade here as well. 
https://us-west-2.console.aws.amazon.com/ecs/v2/clusters/sm2a-sit-airflow/services/sm2a-sit-scheduler/logs?region=us-west-2
![image](https://github.com/user-attachments/assets/38a17410-457d-4863-86d2-9b08e627bc4d)

