### PR TITLE
fix: update to use var in place of local, and to look for stage.domain for hosted zone lookups

### DIFF
--- a/infrastructure/ecs_services/alb.tf
+++ b/infrastructure/ecs_services/alb.tf
@@ -10,7 +10,7 @@ resource "aws_alb" "airflow_webserver" {
 }
 
 resource "aws_route53_record" "ecs-alb-record" {
-  name    = "${lower(local.subdomain)}.${var.domain_name}"
+  name    = "${lower(var.subdomain)}.${var.domain_name}"
   type    = "A"
   zone_id = data.aws_route53_zone.ecs_domain.zone_id
   alias {

--- a/infrastructure/ecs_services/certificate.tf
+++ b/infrastructure/ecs_services/certificate.tf
@@ -1,5 +1,5 @@
 resource "aws_acm_certificate" "ecs-domain-certificate" {
-  domain_name       = "${lower(local.subdomain)}.${var.domain_name}"
+  domain_name       = "${lower(var.subdomain)}.${var.domain_name}"
   validation_method = "DNS"
   tags = {
     Contact = "Abdelhak"
@@ -9,7 +9,7 @@ resource "aws_acm_certificate" "ecs-domain-certificate" {
 
 
 data "aws_route53_zone" "ecs_domain" {
-  name       = "${lower(local.subdomain)}.${var.domain_name}"
+  name       = "${lower(var.stage)}.${var.domain_name}"
   private_zone = false
 }
 


### PR DESCRIPTION
These changes update our modules to not rely on `local` variables defined. Some context:

Our `dev` VEDA SM2A deployment is set up to use `TF_VAR_subdomain` which overrides the local `subdomain` setting
which is defined to be set to `stage` if it exists, and `subdomain` otherwise:
```
  subdomain           = var.subdomain == "null" ? var.stage : var.subdomain
```
https://github.com/NASA-IMPACT/self-managed-apache-airflow/blob/main/infrastructure/ecs_services/locals.tf

This is causing the subdomain value to be set to `sm2a.dev` which then correctly creates the necessary certificate for `sm2a.dev.openveda.cloud`
 https://github.com/NASA-IMPACT/self-managed-apache-airflow/blob/main/infrastructure/ecs_services/certificate.tf#L2

```
resource "aws_acm_certificate" "ecs-domain-certificate" {
  domain_name       = "${lower(local.subdomain)}.${var.domain_name}"
  validation_method = "DNS"
  tags = {
    Contact = "Abdelhak"
    Project = var.project
  }
}
```
but looks for the incorrect hosted zone:
```
data "aws_route53_zone" "ecs_domain" {
  name       = "${lower(local.subdomain)}.${var.domain_name}" # It looks for sm2a.dev.openveda.cloud
  private_zone = false
}
```
It should really be looking for `dev.openveda.cloud`.
However, updating our secret so that we use subdomain instead of `TF_VAR_subdomain` won’t fix the issue alone. 

If we updated our secret to use `subdomain`, then the `local.subdomain` value would evaluate to `var.stage` and the certificate would try to be created for `dev.openveda.cloud` and not `sm2a.dev.openveda.cloud`. But then, the hosted zone lookup would be correct.