### PR TITLE
Fix/remove subdomain from certs

### DIFF
--- a/infrastructure/ecs_services/certificate.tf
+++ b/infrastructure/ecs_services/certificate.tf
@@ -9,7 +9,7 @@ resource "aws_acm_certificate" "ecs-domain-certificate" {
 
 
 data "aws_route53_zone" "ecs_domain" {
-  name       = "${lower(local.subdomain)}.${var.domain_name}"
+  name         = var.domain_name
   private_zone = false
 }
 


### PR DESCRIPTION
Terraform uses data to look up the domain name. Adding a subdomain that is created during deployment results in a 'domain not found' error. This PR reverts the change to use the domain name from data.
