### PR TITLE
fix: fix output typo in worker security group id definition

### DIFF
--- a/infrastructure/ecs_services/outputs.tf
+++ b/infrastructure/ecs_services/outputs.tf
@@ -12,5 +12,5 @@ output "allowed_security_groups_id" {
   ])
 }
 output "worker_security_group_id" {
-  value = aws_security_groups.airflow_worker_service.id
+  value = aws_security_group.airflow_worker_service.id
 }


### PR DESCRIPTION
There's a typo in the output definition:

`aws_security_groups.airflow_worker_service.id` should be `aws_security_group.airflow_worker_service.id` without the `s` 😭 