### PR TITLE
fix: add security group id output to top level outputs

### DIFF
--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -13,3 +13,7 @@ output "database_endpoint" {
 output "airflow_secret_name" {
   value = module.secrets.airflow_secrets
 }
+
+output "worker_security_group_id" {
+  value = module.ecs_services.worker_security_group_id
+}


### PR DESCRIPTION
Need to add this to the top level outputs in order to access it from the sma-base module in veda-data-airflow