### PR TITLE
fix: disable input prompting in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 # Check .env file
 
+export TF_INPUT=0
 
 DOT_ENV=$1
 


### PR DESCRIPTION
Followup from concerns raised in [Slack](https://developmentseed.slack.com/archives/C045K5LAFA9/p1755630073994449) and observed during [VEDA update error](https://github.com/NASA-IMPACT/veda-data-airflow/issues/388#issuecomment-3208586370).

[Relevant TF Docs](https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS#auto-approval-of-plans)

[Hanging example](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/17114776510/job/48543427664#step:5:186) (current)
[Safely exit example](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/17114936050/job/48543865532#step:5:193) (proposed)

https://github.com/NASA-IMPACT/veda-data-airflow/pull/397
https://github.com/NASA-IMPACT/csda-self-managed-airflow/pull/332