### PR TITLE
feat: override ECS worker ephemeral disk space

### DIFF
--- a/infrastructure/ecs_services/airflow_worker.tf
+++ b/infrastructure/ecs_services/airflow_worker.tf
@@ -19,6 +19,14 @@ resource "aws_ecs_task_definition" "airflow_worker" {
     operating_system_family = "LINUX"
     cpu_architecture        = var.task_cpu_architecture
   }
+  # Only emit the block when raising storage above the Fargate default (20 GiB).
+  # The API rejects size_in_gib = 20; omitting the block keeps the 20 GiB default.
+  dynamic "ephemeral_storage" {
+    for_each = var.worker_ephemeral_storage > 20 ? [1] : []
+    content {
+      size_in_gib = var.worker_ephemeral_storage
+    }
+  }
   requires_compatibilities = ["FARGATE"]
   container_definitions = jsonencode([
     {

--- a/infrastructure/ecs_services/variables.tf
+++ b/infrastructure/ecs_services/variables.tf
@@ -54,6 +54,14 @@ variable "worker_cpu" {
 variable "worker_memory" {
 
 }
+variable "worker_ephemeral_storage" {
+  description = "Amount of ephemeral storage (in GiB) for the worker Fargate task. Use 20 to keep the Fargate default (the ephemeral_storage block is omitted); to raise it, set a value between 21 and 200."
+  default     = 20
+  validation {
+    condition     = var.worker_ephemeral_storage == 20 || (var.worker_ephemeral_storage >= 21 && var.worker_ephemeral_storage <= 200)
+    error_message = "worker_ephemeral_storage must be 20 (Fargate default) or between 21 and 200 GiB."
+  }
+}
 
 variable "custom_worker_policy_statement" {
   type = list(object({

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -85,6 +85,7 @@ module "ecs_services" {
   public_subnet_ids                = data.aws_subnets.public_subnets_id.ids
   worker_cpu                       = var.worker_cpu
   worker_memory                    = var.worker_memory
+  worker_ephemeral_storage         = var.worker_ephemeral_storage
 
   custom_worker_policy_statement = var.custom_worker_policy_statement
   number_of_schedulers           = var.number_of_schedulers

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -119,6 +119,14 @@ variable "worker_cpu" {
 variable "worker_memory" {
   default = 4096 * 2
 }
+variable "worker_ephemeral_storage" {
+  description = "Amount of ephemeral storage (in GiB) for the worker Fargate task. Use 20 to keep the Fargate default (the ephemeral_storage block is omitted); to raise it, set a value between 21 and 200."
+  default     = 20
+  validation {
+    condition     = var.worker_ephemeral_storage == 20 || (var.worker_ephemeral_storage >= 21 && var.worker_ephemeral_storage <= 200)
+    error_message = "worker_ephemeral_storage must be 20 (Fargate default) or between 21 and 200 GiB."
+  }
+}
 
 variable "custom_worker_policy_statement" {
   type = list(object({


### PR DESCRIPTION
## Background

Ref - https://github.com/NASA-IMPACT/csda-project/issues/2386

Over in CSDA we have a workflow that unfortunately needs quite a bit of local disk space. By default ECS via Fargate provisions 20GiB of ephemeral storage, but this can be increased to up to 200GiB.

This PR adds a pass through for this [ecs_task_definition.ephemeral_storage.size_in_gib](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#ephemeral_storage) similar to how the worker CPU & memory variables work.

Running `terraform plan` from CSDA's SM2A while pointing at this local modification shows the expected delta in the plan under the Airflow worker task definition block,

```
      + ephemeral_storage { # forces replacement
          + size_in_gib = 100 # forces replacement
        }
```

### Keeping this a no-op by default

The docs and [the code](https://github.com/hashicorp/terraform-provider-aws/blob/v6.51.0/internal/service/ecs/task_definition.go#L145-L151) require the `size_in_gib` must be `21 <= size_in_gib <= 200`, which presents a small challenge to make this a no-op.

Ideally I would just keep the default as `20`, but that would fail parameter validation. Instead, I set a condition such that we only populate the value if it's set `size_in_gib > 20`. I also added input validation to ensure the user inputs `200 >= size_in_gib >= 20` with a clear error message.

I double checked the parameter validation by setting to a silly value (2000GiB),
```
│ Error: Invalid value for variable
│
│   on main.tf line 41, in module "sma-base":
│   41:   worker_ephemeral_storage          = 2000
│     ├────────────────
│     │ var.worker_ephemeral_storage is 2000
│
│ worker_ephemeral_storage must be 20 (Fargate default) or between 21 and 200 GiB.
```