### PR TITLE
fix: make celery broker SQS visibility timeout configurable, default 30m

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,6 +1,7 @@
 module "sqs_queue" {
-  source = "./sqs"
-  prefix = var.prefix
+  source                     = "./sqs"
+  prefix                     = var.prefix
+  visibility_timeout_seconds = var.celery_broker_visibility_timeout_seconds
 }
 
 resource "random_password" "jwt_secret_generated" {

--- a/infrastructure/sqs/main.tf
+++ b/infrastructure/sqs/main.tf
@@ -2,4 +2,16 @@
 # https://docs.celeryproject.org/en/stable/getting-started/backends-and-brokers/sqs.html
 resource "aws_sqs_queue" "celery_broker" {
   name_prefix = "${var.prefix}-celery-broker-"
+
+  # Must exceed the runtime of the longest Airflow task. When SQS makes a message
+  # visible again while its task is still running, the message is redelivered and a
+  # second worker attempts to start the same task instance. On Airflow 3 the Task
+  # Execution API rejects that second start with `invalid_state`, the Celery executor
+  # reports the task as failed, and the scheduler then kills the healthy original run.
+  # The task fails despite never having errored.
+  #
+  # This must be set here rather than through celery's broker_transport_options: the
+  # Airflow config uses `predefined_queues`, so kombu does not create the queue and
+  # the queue's own attribute is what governs redelivery.
+  visibility_timeout_seconds = var.visibility_timeout_seconds
 }

--- a/infrastructure/sqs/variables.tf
+++ b/infrastructure/sqs/variables.tf
@@ -1,1 +1,7 @@
 variable "prefix" {}
+
+variable "visibility_timeout_seconds" {
+  description = "Visibility timeout for the celery broker queue, in seconds. Must exceed the runtime of the longest Airflow task."
+  type        = number
+  default     = 1800
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -280,3 +280,19 @@ variable "alb_access_logs_prefix" {
   type        = string
   default     = null
 }
+
+variable "celery_broker_visibility_timeout_seconds" {
+  description = <<-EOT
+    Visibility timeout for the celery broker SQS queue, in seconds. Must exceed the
+    runtime of the longest Airflow task, or SQS redelivers the message mid-run and the
+    duplicate delivery fails the task. Defaults to 30 minutes; raise it if any task
+    routinely runs longer. SQS allows up to 43200 (12h).
+  EOT
+  type        = number
+  default     = 1800
+
+  validation {
+    condition     = var.celery_broker_visibility_timeout_seconds >= 30 && var.celery_broker_visibility_timeout_seconds <= 43200
+    error_message = "celery_broker_visibility_timeout_seconds must be between 30 and 43200 (SQS limits)."
+  }
+}


### PR DESCRIPTION
Increase SQS timeout threshold to prevent long-running tasks from failing. This is configurable, and defaults to 30m (the longest impacted task I found in our dev environment was 11m, so this is generous).